### PR TITLE
Fix multiple issues with the code

### DIFF
--- a/nip.nim
+++ b/nip.nim
@@ -1,14 +1,19 @@
-import std/httpclient
-import strutils
+## Quick multi-platform nim package to pull public IP address
+## 
+## Can be imported or compiled as stand alone program
 
-# Quick multi-platform nim package to pull public IP address
-# Can be imported or compiled as stand alone program
+import std/[httpclient, strutils]
 
 const source = "https://icanhazip.com" # Use whatever
 
 proc nip*(): string =
+    ## Get the public IP address of the current host 
     var client = newHttpClient()
-    var response = getContent(client, source)
-    return response.strip()
+    try:
+        let response = client.getContent(source)
+        result = response.strip()
+    finally:
+        client.close()
 
-echo nip()
+when isMainModule:
+    echo nip()

--- a/nip.nimble
+++ b/nip.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version     = "0.0.1"
+version     = "0.0.2"
 author      = "no-waves"
 description = "simple nim lib to get IP address"
 license     = "MIT"


### PR DESCRIPTION
- Moved the top-level comments of the package to the top so they're actually doc comments.
- Merged the imports (you can import any stdlib modules with the `std` prefix and group them together).
- Added a small docstring to the proc itself.
- Fixed a leak in the package - you need to `close` HttpClient after using it.
- Moved `echo nip()` under `when isMainModule` so it doesn't execute when you use `nip` as a library.

Also bumped the .nimble version